### PR TITLE
fixity  _`⊜_  Tactic/RingSolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 - [ ] src/Foreign/Haskell/Pair.agda:24,15-18 --- \_,\_ - `infixr 4` - document this in `README.Design.Fixity`
 
-- [ ] src/Tactic/RingSolver.agda:144,3-7 --- \_`⊜\_
+- [ ] src/Tactic/RingSolver.agda:144,3-7 --- \_`⊜\_  - `infix 6` 
 
 - [ ] src/Tactic/RingSolver.agda:78,15-40 --- add⇒\_mul⇒\_pow⇒\_neg⇒\_sub⇒\_
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 
 - [ ] src/Reflection/AST/AlphaEquality.agda:86,3-306,20 --- \_=α=-AbsTerm\_, \_=α=-ArgPattern\_, \_=α=-ArgTerm\_, \_=α=-ArgsPattern\_, \_=α=-ArgsTerm\_, \_=α=-Clause\_, \_=α=-Clauses\_, \_=α=-Pattern\_, \_=α=-Sort\_, \_=α=-Telescope\_, \_=α=-Term\_
 
-- [ ] src/Tactic/RingSolver/Core/Expression.agda:27,3-5 --- ⊝\_
+- [ ] src/Tactic/RingSolver/Core/Expression.agda:27,3-5 --- ⊝\_ - `infix 8`
 
 - [ ] src/Tactic/RingSolver/Core/Polynomial/Homomorphism/Lemmas.agda:104,1-7 --- \_⟦∷⟧?\_Lemmas-14607523571404377151
 


### PR DESCRIPTION
- infixl 6 `` _`⊜_ `` because : 

```
src/Tactic/RingSolver.agda:144,3-7 --- _`⊜_
  		 _`⊜_ : Term → Term → Term
  		 x `⊜ y = quote _⊜_  $ʳ (`numberOfVariables ⟅∷⟆ x ⟨∷⟩ y ⟨∷⟩ [])
 ``` 		 
  		
 where  `_⊜_`  is in Tactic.RingSolver.NonReflective
`infixl 6 _⊜_`



- `infix 8   ⊝_`  

src/Tactic/RingSolver.agda : 
    `⊝_  : Expr A n → Expr A n            -- Negation` 
 → -- negation-like  infix  8 ¬_