### PR TITLE
Proposition fixities Relation.Unary.Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,13 @@
 
 - [ ] src/Algebra/Solver/Ring/AlmostCommutativeRing.agda:79,8-33 --- \_-Raw-AlmostCommutative⟶\_
 
-- [ ] src/Relation/Unary/Properties.agda:205,1-226,4 --- \_~?, \_×?\_, \_∩?\_, \_∪?\_, \_⊎?\_, \_⊙?\_
+- [ ] src/Relation/Unary/Properties.agda:205,1-226,4 ---
+  - \_~?  `infix 10`
+  - \_×?\_ `infix 2`
+  - \_∩?\_ `infix 7`
+  - \?\_ `infix 6`
+  - \_⊎?\_ `infix 1`
+  - \_⊙?\_ `infix 2`
 
 - [ ] src/Function/Construct/Composition.agda:240,1-282,6 --- \_∘-↔\_, \_∘-↠\_, \_∘-↣\_, \_∘-↩\_, \_∘-↪\_, \_∘-⇔\_, \_∘-⟶\_, \_∘-⤖\_ - `infixr 9`
 


### PR DESCRIPTION
 src/Relation/Unary/Properties.agda:205,1-226,4 --- `_~?, _×?_, _∩?_, _∪?_, _⊎?_, _⊙?_`
 `_∩?_ ` → and-like ` infixr 7 _∧_ `           [(`infixr 7 _∩_`)](https://github.com/agda/agda-stdlib/blob/master/src/Relation/Unary.agda)
 `_∪?_ `→ or-like ` infixr 6 _∨_ `               [(`infixr 6 _∪_`)](https://github.com/agda/agda-stdlib/blob/master/src/Relation/Unary.agda)
 `_⊎?_ `→ sum-like `infixr 1 _⊎_ `            [(`infixr  1 _⟨⊎⟩_`)](https://github.com/agda/agda-stdlib/blob/master/src/Relation/Unary.agda)
 `_⊙?_`→ 				               [(`infixr  2 _⟨⊙⟩_`)](https://github.com/agda/agda-stdlib/blob/master/src/Relation/Unary.agda)
 `_×?_` → product-like `infixr 2 _×_`         [(`infixr  2 _⟨×⟩_`)](https://github.com/agda/agda-stdlib/blob/master/src/Relation/Unary.agda)
 `_~?`   →					       [(`infix  10 _~`)](https://github.com/agda/agda-stdlib/blob/master/src/Relation/Unary.agda)